### PR TITLE
Configure Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Python image as a base
+FROM python:3.12
+
+# Set the working directory for the API
+WORKDIR /
+
+# Copy the requirements.txt file
+COPY requirements.txt .
+
+# Install dependencies
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
+
+# Copy the rest of the API into the container
+COPY / .
+
+# Expose the port that FastAPI uses
+EXPOSE 8000
+
+# Command to start the API
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload", "--app-dir", "books-api"]

--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ cd API-Livres
          mongosh
          ```
 
-4. **Install Postman App**
+4. **Install Docker**
+
+Docker is an open platform that wraps our applications from our infrastructure. 
+
+   1. Install Docker Desktop on your local machine (https://docs.docker.com/get-started/introduction/get-docker-desktop/) and complete setup process.
+
+5. **Install Postman App**
    1. Download the installer adapted for your OS from the [Postman Download Center](https://www.postman.com/downloads/).
    2. Run the installer MSI and follow the on-screen instructions.
    3. Install Postman Agent if you use the web version.

--- a/books-api/app/database.py
+++ b/books-api/app/database.py
@@ -3,7 +3,7 @@
 import motor.motor_asyncio
 
 # Connection details
-MONGO_DETAILS = "mongodb://localhost:27017"
+MONGO_DETAILS = "mongodb://mongodb:27017"
 
 # Creating an asynchronous client for MongoDB
 client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_DETAILS)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+
+services:
+  # API service
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./books-api/app:/app
+    depends_on:
+      - mongodb
+    restart: always
+  
+  # MongoDB Database
+  mongodb:
+    image: mongo:latest
+    restart: always
+    ports:
+      - '27017:27017' # default mongodb port
+    volumes:
+      - /data/db:/data/db


### PR DESCRIPTION
- Add Dockerfile for the API
- Create a docker-compose to manage the API docker and the database docker. For MongoDB, we use the official image.
- Add instructions to install Docker Desktop in the Readme;